### PR TITLE
To work on new SDK versions

### DIFF
--- a/android/src/main/java/br/com/oi/reactnative/module/datausage/DataUsagePackage.java
+++ b/android/src/main/java/br/com/oi/reactnative/module/datausage/DataUsagePackage.java
@@ -22,7 +22,7 @@ public class DataUsagePackage implements ReactPackage {
         return modules;
     }
 
-    @Override
+    //@Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
 
         return Collections.emptyList();


### PR DESCRIPTION
The interface "ReactPackage" don't have a method sign "createJSModules" then @Override isn't necessary.

https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/ReactPackage.java