### PR TITLE
'compile' is obsolete, changed to 'implementation'

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,5 +40,5 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
Font: https://docs.gradle.org/current/userguide/java_library_plugin.html
Son 'compile' will not work any more.