### PR TITLE
Catch permission errors from the recent android apis

### DIFF
--- a/android/src/main/java/br/com/oi/reactnative/module/datausage/DataUsageModule.java
+++ b/android/src/main/java/br/com/oi/reactnative/module/datausage/DataUsageModule.java
@@ -461,11 +461,11 @@ public class DataUsageModule extends ReactContextBaseJavaModule {
                 return new JSONObject().put("name", name)
                                         .put("packageName", packageName)
                                         .put("rx", rx)
-                                        .put("received", String.format("%.2f MB", ((rx / 1024D) / 1024D) ))
+                                        .put("received", String.format("%.3f MB", ((rx / 1024D) / 1024D) ))
                                         .put("tx", tx)
-                                        .put("sent", String.format("%.2f MB", ((tx / 1024D) / 1024D) ))
+                                        .put("sent", String.format("%.3f MB", ((tx / 1024D) / 1024D) ))
                                         .put("total", total)
-                                        .put("totalMb", String.format("%.2f MB", (total / 1024D) / 1024D ))
+                                        .put("totalMb", String.format("%.3f MB", (total / 1024D) / 1024D ))
                                         .put("icon", encodedImage);
             }
         } catch (JSONException e) {

--- a/android/src/main/java/br/com/oi/reactnative/module/datausage/helper/NetworkStatsHelper.java
+++ b/android/src/main/java/br/com/oi/reactnative/module/datausage/helper/NetworkStatsHelper.java
@@ -139,7 +139,7 @@ public class NetworkStatsHelper {
         networkStats.getNextBucket(bucket);
         long tx = bucket.getTxBytes();
         networkStats.close();
-        Log.i("data tx:", tx);
+        Log.i("data tx:" + tx);
         return tx;
     }
 

--- a/android/src/main/java/br/com/oi/reactnative/module/datausage/helper/NetworkStatsHelper.java
+++ b/android/src/main/java/br/com/oi/reactnative/module/datausage/helper/NetworkStatsHelper.java
@@ -138,6 +138,7 @@ public class NetworkStatsHelper {
         networkStats.getNextBucket(bucket);
         long tx = bucket.getTxBytes();
         networkStats.close();
+        Log.i("data tx:", tx);
         return tx;
     }
 

--- a/android/src/main/java/br/com/oi/reactnative/module/datausage/helper/NetworkStatsHelper.java
+++ b/android/src/main/java/br/com/oi/reactnative/module/datausage/helper/NetworkStatsHelper.java
@@ -10,6 +10,7 @@ import android.os.RemoteException;
 import android.telephony.TelephonyManager;
 
 import java.util.Date;
+import java.util.Log;
 
 @TargetApi(Build.VERSION_CODES.M)
 public class NetworkStatsHelper {
@@ -115,7 +116,7 @@ public class NetworkStatsHelper {
         networkStats.getNextBucket(bucket);
         long rx = bucket.getRxBytes();
         networkStats.close();
-        Log.i(rx);
+        Log.i("rx",rx);
         return rx;
     }
 
@@ -139,7 +140,7 @@ public class NetworkStatsHelper {
         networkStats.getNextBucket(bucket);
         long tx = bucket.getTxBytes();
         networkStats.close();
-        Log.i(tx);
+        Log.i("tx:", tx);
         return tx;
     }
 

--- a/android/src/main/java/br/com/oi/reactnative/module/datausage/helper/NetworkStatsHelper.java
+++ b/android/src/main/java/br/com/oi/reactnative/module/datausage/helper/NetworkStatsHelper.java
@@ -139,7 +139,7 @@ public class NetworkStatsHelper {
         networkStats.getNextBucket(bucket);
         long tx = bucket.getTxBytes();
         networkStats.close();
-        Log.i("data tx:" + tx);
+        Log.i(tx);
         return tx;
     }
 

--- a/android/src/main/java/br/com/oi/reactnative/module/datausage/helper/NetworkStatsHelper.java
+++ b/android/src/main/java/br/com/oi/reactnative/module/datausage/helper/NetworkStatsHelper.java
@@ -34,7 +34,7 @@ public class NetworkStatsHelper {
         NetworkStats.Bucket bucket;
         try {
             bucket = networkStatsManager.querySummaryForDevice(ConnectivityManager.TYPE_MOBILE,
-                                null,
+                                getSubscriberId(context, ConnectivityManager.TYPE_MOBILE),
                                 startDate != null ? startDate.getTime() : 0,
                                 endDate != null ? endDate.getTime() : System.currentTimeMillis());
         } catch (RemoteException e) {
@@ -51,7 +51,7 @@ public class NetworkStatsHelper {
         NetworkStats.Bucket bucket;
         try {
             bucket = networkStatsManager.querySummaryForDevice(ConnectivityManager.TYPE_MOBILE,
-                                    null,
+                                    getSubscriberId(context, ConnectivityManager.TYPE_MOBILE),
                                     startDate != null ? startDate.getTime() : 0,
                                     endDate != null ? endDate.getTime() : System.currentTimeMillis());
         } catch (RemoteException e) {
@@ -68,7 +68,7 @@ public class NetworkStatsHelper {
         NetworkStats.Bucket bucket;
         try {
             bucket = networkStatsManager.querySummaryForDevice(ConnectivityManager.TYPE_WIFI,
-                                "",
+                                null,
                                 startDate != null ? startDate.getTime() : 0,
                                 endDate != null ? endDate.getTime() : System.currentTimeMillis());
         } catch (RemoteException e) {
@@ -85,7 +85,7 @@ public class NetworkStatsHelper {
         NetworkStats.Bucket bucket;
         try {
             bucket = networkStatsManager.querySummaryForDevice(ConnectivityManager.TYPE_WIFI,
-                    "",
+                    null,
                     startDate != null ? startDate.getTime() : 0,
                     endDate != null ? endDate.getTime() : System.currentTimeMillis());
         } catch (RemoteException e) {
@@ -103,7 +103,7 @@ public class NetworkStatsHelper {
         try {
             networkStats = networkStatsManager.queryDetailsForUid(
                                     ConnectivityManager.TYPE_MOBILE,
-                                    null,
+                                    getSubscriberId(context, ConnectivityManager.TYPE_MOBILE),
                                     startDate != null ? startDate.getTime() : 0,
                                     endDate != null ? endDate.getTime() : System.currentTimeMillis(),
                                     packageUid);
@@ -127,7 +127,7 @@ public class NetworkStatsHelper {
         try {
             networkStats = networkStatsManager.queryDetailsForUid(
                                 ConnectivityManager.TYPE_MOBILE,
-                                null,
+                                getSubscriberId(context, ConnectivityManager.TYPE_MOBILE),
                                 startDate != null ? startDate.getTime() : 0,
                                 endDate != null ? endDate.getTime() : System.currentTimeMillis(),
                                 packageUid);
@@ -150,7 +150,7 @@ public class NetworkStatsHelper {
         try {
             networkStats = networkStatsManager.queryDetailsForUid(
                                 ConnectivityManager.TYPE_WIFI,
-                                "",
+                                null,
                                 startDate != null ? startDate.getTime() : 0,
                                 endDate != null ? endDate.getTime() : System.currentTimeMillis(),
                     packageUid);
@@ -173,7 +173,7 @@ public class NetworkStatsHelper {
         try {
             networkStats = networkStatsManager.queryDetailsForUid(
                                     ConnectivityManager.TYPE_WIFI,
-                                    "",
+                                    null,
                                     startDate != null ? startDate.getTime() : 0,
                                     endDate != null ? endDate.getTime() : System.currentTimeMillis(),
                                     packageUid);
@@ -188,11 +188,13 @@ public class NetworkStatsHelper {
     }
 
     private String getSubscriberId(Context context, int networkType) {
-        if (ConnectivityManager.TYPE_MOBILE == networkType) {
-            TelephonyManager tm = (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
-            return tm.getSubscriberId();
+        try{
+            if (ConnectivityManager.TYPE_MOBILE == networkType) {
+                TelephonyManager tm = (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
+                return tm.getSubscriberId();
+            }
+        } catch(Exception e) {
+            return null;
         }
-
-        return "";
     }
 }

--- a/android/src/main/java/br/com/oi/reactnative/module/datausage/helper/NetworkStatsHelper.java
+++ b/android/src/main/java/br/com/oi/reactnative/module/datausage/helper/NetworkStatsHelper.java
@@ -196,5 +196,6 @@ public class NetworkStatsHelper {
         } catch(Exception e) {
             return null;
         }
+        return null;
     }
 }

--- a/android/src/main/java/br/com/oi/reactnative/module/datausage/helper/NetworkStatsHelper.java
+++ b/android/src/main/java/br/com/oi/reactnative/module/datausage/helper/NetworkStatsHelper.java
@@ -51,7 +51,7 @@ public class NetworkStatsHelper {
         NetworkStats.Bucket bucket;
         try {
             bucket = networkStatsManager.querySummaryForDevice(ConnectivityManager.TYPE_MOBILE,
-                                    getSubscriberId(context, ConnectivityManager.TYPE_MOBILE),
+                                    "",
                                     startDate != null ? startDate.getTime() : 0,
                                     endDate != null ? endDate.getTime() : System.currentTimeMillis());
         } catch (RemoteException e) {
@@ -103,7 +103,7 @@ public class NetworkStatsHelper {
         try {
             networkStats = networkStatsManager.queryDetailsForUid(
                                     ConnectivityManager.TYPE_MOBILE,
-                                    getSubscriberId(context, ConnectivityManager.TYPE_MOBILE),
+                                    "",
                                     startDate != null ? startDate.getTime() : 0,
                                     endDate != null ? endDate.getTime() : System.currentTimeMillis(),
                                     packageUid);
@@ -127,7 +127,7 @@ public class NetworkStatsHelper {
         try {
             networkStats = networkStatsManager.queryDetailsForUid(
                                 ConnectivityManager.TYPE_MOBILE,
-                                getSubscriberId(context, ConnectivityManager.TYPE_MOBILE),
+                                "",
                                 startDate != null ? startDate.getTime() : 0,
                                 endDate != null ? endDate.getTime() : System.currentTimeMillis(),
                                 packageUid);

--- a/android/src/main/java/br/com/oi/reactnative/module/datausage/helper/NetworkStatsHelper.java
+++ b/android/src/main/java/br/com/oi/reactnative/module/datausage/helper/NetworkStatsHelper.java
@@ -34,7 +34,7 @@ public class NetworkStatsHelper {
         NetworkStats.Bucket bucket;
         try {
             bucket = networkStatsManager.querySummaryForDevice(ConnectivityManager.TYPE_MOBILE,
-                                getSubscriberId(context, ConnectivityManager.TYPE_MOBILE),
+                                "",
                                 startDate != null ? startDate.getTime() : 0,
                                 endDate != null ? endDate.getTime() : System.currentTimeMillis());
         } catch (RemoteException e) {

--- a/android/src/main/java/br/com/oi/reactnative/module/datausage/helper/NetworkStatsHelper.java
+++ b/android/src/main/java/br/com/oi/reactnative/module/datausage/helper/NetworkStatsHelper.java
@@ -34,7 +34,7 @@ public class NetworkStatsHelper {
         NetworkStats.Bucket bucket;
         try {
             bucket = networkStatsManager.querySummaryForDevice(ConnectivityManager.TYPE_MOBILE,
-                                getSubscriberId(context, ConnectivityManager.TYPE_MOBILE),
+                                null,
                                 startDate != null ? startDate.getTime() : 0,
                                 endDate != null ? endDate.getTime() : System.currentTimeMillis());
         } catch (RemoteException e) {
@@ -51,7 +51,7 @@ public class NetworkStatsHelper {
         NetworkStats.Bucket bucket;
         try {
             bucket = networkStatsManager.querySummaryForDevice(ConnectivityManager.TYPE_MOBILE,
-                                    getSubscriberId(context, ConnectivityManager.TYPE_MOBILE),
+                                    null,
                                     startDate != null ? startDate.getTime() : 0,
                                     endDate != null ? endDate.getTime() : System.currentTimeMillis());
         } catch (RemoteException e) {
@@ -103,7 +103,7 @@ public class NetworkStatsHelper {
         try {
             networkStats = networkStatsManager.queryDetailsForUid(
                                     ConnectivityManager.TYPE_MOBILE,
-                                    getSubscriberId(context, ConnectivityManager.TYPE_MOBILE),
+                                    null,
                                     startDate != null ? startDate.getTime() : 0,
                                     endDate != null ? endDate.getTime() : System.currentTimeMillis(),
                                     packageUid);
@@ -127,7 +127,7 @@ public class NetworkStatsHelper {
         try {
             networkStats = networkStatsManager.queryDetailsForUid(
                                 ConnectivityManager.TYPE_MOBILE,
-                                getSubscriberId(context, ConnectivityManager.TYPE_MOBILE),
+                                null,
                                 startDate != null ? startDate.getTime() : 0,
                                 endDate != null ? endDate.getTime() : System.currentTimeMillis(),
                                 packageUid);

--- a/android/src/main/java/br/com/oi/reactnative/module/datausage/helper/NetworkStatsHelper.java
+++ b/android/src/main/java/br/com/oi/reactnative/module/datausage/helper/NetworkStatsHelper.java
@@ -115,6 +115,7 @@ public class NetworkStatsHelper {
         networkStats.getNextBucket(bucket);
         long rx = bucket.getRxBytes();
         networkStats.close();
+        Log.i(rx);
         return rx;
     }
 
@@ -138,6 +139,7 @@ public class NetworkStatsHelper {
         networkStats.getNextBucket(bucket);
         long tx = bucket.getTxBytes();
         networkStats.close();
+        Log.i("data tx:", tx);
         return tx;
     }
 


### PR DESCRIPTION
The getSubscriberId is now not working in Android 10 as it requires READ_PRIVILEGED_PHONE_STATE which third-party apps cannot have.  This PR ensures that if getSubscriberId raises an exception, we give return null. 

Fix #1 